### PR TITLE
add backtracking support to many/p for trailing separator

### DIFF
--- a/megaparsack-lib/megaparsack/combinator.rkt
+++ b/megaparsack-lib/megaparsack/combinator.rkt
@@ -73,7 +73,7 @@
         (pure '())
         (or/p (lazy/p ((pure cons) p (loop-optional recur (sub1 max-count))))
               (pure '()))))
-  (loop-mandatory p #:recur-parser (do sep p)))
+  (loop-mandatory p #:recur-parser (try/p (do sep p))))
 
 (define (many+/p p #:sep [sep void/p] #:max [max-count +inf.0])
   (many/p p #:sep sep #:min 1 #:max max-count))

--- a/megaparsack-test/tests/megaparsack/base.rkt
+++ b/megaparsack-test/tests/megaparsack/base.rkt
@@ -90,6 +90,13 @@
     (it "succeeds with only letters when parsing dotted letters"
       (check-equal? (parse-string many-dotted-letters/p "a.b.c")
                     (success (list #\a #\b #\c)))))
+  (context "when given a parser with trailing separator"
+    (define many-trailing-sep/p (do (many/p (char/p #\a)
+                                            #:sep (char/p #\.))
+                                    (char/p #\.)))
+    (it "succeeds with backtracking"
+      (check-equal? (parse-string many-trailing-sep/p "a.a.a.")
+                    (success #\.))))
   (context "when given a letter parser and a maximum count of three"
     (define at-most-three-letters/p (many/p letter/p #:max 3))
     (it "succeeds when parsing three letters"


### PR DESCRIPTION
Fix #27 if that's a valid issue.